### PR TITLE
maintainers: remove flatcar-docs repository

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,10 +16,11 @@ maintainers:
 * Thilo Fromm @t-lo
 * Krzesimir Nowak @krnowak
 
-### flatcar-docs
+### flatcar-website
 maintainers:
 * Kai Lüke @pothos
 * Thilo Fromm @t-lo
+* Mathieu Tortuyaux @tormath1
 
 ### mantle
 maintainers:


### PR DESCRIPTION
Follow-up from https://github.com/flatcar/flatcar-website/pull/280.

BTW, it seems that `flatcar-website` is not listed.