### PR TITLE
docs: Fix SECURITY.md spelling.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,12 @@
-# Flatcar Security 
+# Flatcar Security
 To keep Flatcar secure, the maintainers put a strong focus on tracking new and existing security issues.
-Dealing with Security concerns is owned by the [Flatcar Security team](https://github.com/orgs/flatcar/teams/flatcar-security-team), a sub-set of the Maintainers team, and elected by the Maintainers (see [governance.md](./governance.md)).
+Dealing with Security concerns is owned by the [Flatcar Security team](https://github.com/orgs/flatcar/teams/flatcar-security-team), a subset of the Maintainers team, and elected by the Maintainers (see [governance.md](./governance.md)).
 
 While the team actively researches and tracks new and existing security issues, it may also be notified of issues via [security@flatcar-linux.org](mailto:security@flatcar-linux.org).
 
-The Security team meets in a fortnightly cadence, in a private video call.
+The Security team meets on a fortnightly cadence, in a private video call.
 The team maintains an internal list of security Primaries and Secondaries, which are rotated on a weekly basis. 
-Primary and Secondary are expected to actively engage in security work each day, including executing the Runbook (see below) and working on fixing ongoing security issues.
+The Primary and Secondary are expected to actively engage in security work each day, including executing the Runbook (see below) and working on fixing ongoing security issues.
 
 Undisclosed security issues are tracked in a private repository only accessible by members of the security team.
 Public issues are tracked publicly in the project's main issue tracker.
@@ -15,7 +15,7 @@ Security issues are addressed by releasing an updated OS image. Releases may be 
 
 ## Daily security runbook for Security team primaries and secondaries
 
-The runbook below discusses steps for identifying new potential security issues and for making the issues known to the Flatcar project's maintainers and / or the other members of the Security team.
+The runbook below discusses steps for identifying new potential security issues and for making the issues known to the Flatcar project's maintainers and/or the other members of the Security team.
 
 Primaries are expected to execute the runbook at least once per day, optionally assisted or off-loaded by Secondaries.
 
@@ -26,4 +26,4 @@ Every day look into upstream security trackers like below:
 - Rust security announcements
 - (optional) issue trackers of other distros
 - Whenever we discover any new CVE, we add it to an internal database, and use automation tools to create a new issue about the CVE in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues) with labels `security` and `advisory`.
-- If an issue of updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.
+- If an issue for updating the specific package affected by the new CVE is already open in [Flatcar GitHub issues](https://github.com/Flatcar/Flatcar/issues), then unfortunately we need to manually edit the existing issue to add the new CVE.


### PR DESCRIPTION
# Fix `SECURITY.md` spelling

Fixed some spelling issues.
I reviewed the `SECURITY.md`, the link to the Flatcar Security team is not working for externals
https://github.com/flatcar/Flatcar/blob/main/SECURITY.md#flatcar-security
