### PR TITLE
docs: update onboarding and contributing documents, add releases guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,22 @@ Welcome! We're so glad you're here and interested in contributing to Flatcar! �
 
 ## Table of Contents
 
-- [Ways to Contribute](#ways-to-contribute)
-- [Getting Started](#getting-started)
-  - [Finding Issues](#finding-issues)
-  - [Proposing New Features](#proposing-new-features)
-- [Communication Channels](#communication-channels)
-  - [Community Meetings](#community-meetings)
-- [Development](#development)
-  - [Development Environment Setup](#development-environment-setup)
-  - [Pull Request Lifecycle](#pull-request-lifecycle)
-  - [Authoring PRs](#authoring-prs)
-  - [Commit Guidelines](#commit-guidelines)
+- [Contributing Guide](#contributing-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Ways to Contribute](#ways-to-contribute)
+  - [Getting Started](#getting-started)
+    - [Finding Issues](#finding-issues)
+    - [Proposing New Features](#proposing-new-features)
+  - [Communication Channels](#communication-channels)
+  - [Development](#development)
+    - [Development Environment Setup](#development-environment-setup)
+    - [Pull Request Lifecycle](#pull-request-lifecycle)
+    - [Authoring PRs](#authoring-prs)
+      - [Commit Best Practices](#commit-best-practices)
+      - [PR Description](#pr-description)
+    - [Commit Guidelines](#commit-guidelines)
+      - [The Rules](#the-rules)
+      - [Examples](#examples)
 
 ---
 
@@ -32,18 +37,18 @@ If something doesn't make sense or doesn't work, please let us know by opening a
 
 There are so many ways to get involved! We welcome all kinds of contributions:
 
-| Category | Examples |
-|----------|----------|
-| **Code** | New features, bug fixes, builds, CI/CD |
-| **Documentation** | Guides, tutorials, API docs |
-| **Community** | Issue triage, answering questions on Slack/Matrix/Mailing Lists |
-| **Flatcar Apps** | Create reference implementations for running services on Flatcar (e.g., [Minecraft](https://github.com/flatcar/flatcar-app-minecraft), [Jitsi](https://github.com/flatcar/flatcar-app-jitsi)) — great for learning! |
-| **Outreach** | Blog posts, talks, presentations, workshops |
-| **Coordination** | Release management, upstream project coordination (e.g., Flatcar CAPI, sysext initiative) |
-| **Events** | Bug fixing days, doc writing days, devrooms, meetups, conferences |
-| **Design** | Web design, maintaining the Flatcar website |
+| Category          | Examples                                                                                                                                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Code**          | New features, bug fixes, builds, CI/CD                                                                                                                                                                              |
+| **Documentation** | Guides, tutorials, API docs                                                                                                                                                                                         |
+| **Community**     | Issue triage, answering questions on Discord/Matrix/Slack                                                                                                                                                           |
+| **Flatcar Apps**  | Create reference implementations for running services on Flatcar (e.g., [Minecraft](https://github.com/flatcar/flatcar-app-minecraft), [Jitsi](https://github.com/flatcar/flatcar-app-jitsi)) — great for learning! |
+| **Outreach**      | Blog posts, talks, presentations, workshops                                                                                                                                                                         |
+| **Coordination**  | Release management, upstream project coordination (e.g., Flatcar CAPI, sysext initiative)                                                                                                                           |
+| **Events**        | Bug fixing days, doc writing days, devrooms, meetups, conferences                                                                                                                                                   |
+| **Design**        | Web design, maintaining the Flatcar website                                                                                                                                                                         |
 
-Not everything happens through a GitHub pull request. Please come to our [meetings](#community-meetings) or [contact us](mailto:maintainers@flatcar-linux.org) to discuss how we can work together — we'd love to meet you!
+Not everything happens through a GitHub pull request. Please come to our [meetings or contact us](https://github.com/flatcar/Flatcar/blob/main/README.md#community-meetings) to discuss how we can work together — we'd love to meet you!
 
 ---
 
@@ -57,12 +62,12 @@ To report bugs or request features, just file an [issue](https://github.com/flat
 
 Not sure where to start? No worries — we've got you covered!
 
-| Label | Description |
-|-------|-------------|
+| Label                                                                                                                 | Description                                             |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | [`good first issue`](https://github.com/flatcar/Flatcar/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) | Extra guidance to help you make your first contribution |
-| [`help wanted`](https://github.com/flatcar/Flatcar/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) | Issues suitable for non-core maintainers |
+| [`help wanted`](https://github.com/flatcar/Flatcar/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)           | Issues suitable for non-core maintainers                |
 
-> 💡 **Tip:** Don't see any issues with these labels? No problem! There's always something exciting to work on. Hop on Matrix or join one of our Office Hours — we'll find something that fits your interests and skill level.
+> 💡 **Tip:** Don't see any issues with these labels? No problem! There's always something exciting to work on. Hop on [Discord](https://discord.gg/PMYjFUsJyq) or join one of our Office Hours — we'll find something that fits your interests and skill level.
 
 > 🌟 **Great for newcomers:** Consider contributing a [Flatcar App](https://github.com/flatcar/Flatcar/issues/2029)! A Flatcar App is a reference implementation showing how to run a specific service on Flatcar (e.g., [Minecraft Server](https://github.com/flatcar/flatcar-app-minecraft), [Jitsi](https://github.com/flatcar/flatcar-app-jitsi)). It's a fantastic way to learn Flatcar hands-on while creating something awesome that helps other newcomers learn too!
 
@@ -78,44 +83,7 @@ For package requests, use the "New Package Request" issue type and check out [Ad
 
 ## Communication Channels
 
-We're a friendly bunch and always excited to chat! Here's where you can find us:
-
-| Channel | Link |
-|---------|------|
-| **Matrix** (preferred) | 💬 [#flatcar:matrix.org](https://app.element.io/#/room/#flatcar:matrix.org) |
-| **Slack** | [#flatcar](https://kubernetes.slack.com/archives/C03GQ8B5XNJ) (Kubernetes Slack) |
-| **GitHub Discussions** | [flatcar/Flatcar/discussions](https://github.com/flatcar/Flatcar/discussions) |
-| **Mailing List (Users)** | [flatcar-linux-user](https://groups.google.com/g/flatcar-linux-user) |
-
-> Matrix and GitHub Discussions are the preferred ways to interact with the Flatcar community.
-
-### Community Meetings
-
-We love meeting our contributors and users! Come say hi! Check our [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_ii991mqrpta9en8o7ofd4v19g4@group.calendar.google.com) ([iCal](https://calendar.google.com/calendar/ical/c_ii991mqrpta9en8o7ofd4v19g4%40group.calendar.google.com/public/basic.ics)) for all meeting times!
-
-#### Office Hours
-
-| | |
-|---|---|
-| **When** | 2nd Wednesday of every month at 2:30pm UTC (check calendar) |
-| **Where** | [meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours) |
-| **Agenda** | [Office Hours Discussions](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-office-hours) |
-
-Join us to chat with the Flatcar community, hear about where the project is headed, discuss your contributions, and catch occasional demos of image-based Linux technologies. We also do a quick Release Planning update each call.
-
-Got something to share or a burning question? We want to hear from you! Comment on the meeting discussion beforehand, ping us on Matrix, or just show up and speak up during Q&A — newcomers are especially welcome!
-
-#### Developer Syncs
-
-| | |
-|---|---|
-| **When** | 4th Wednesday of every month at 2:30pm UTC (check calendar) |
-| **Where** | [meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours) |
-| **Agenda** | [Developer Sync Discussions](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-developer-sync) |
-
-These calls are where we roll up our sleeves and dig into the work — backlog grooming, task planning, roadmap discussions, and tackling day-to-day issues. If you're looking to get hands-on with development, this is the call for you! We also cover Release Planning here, just like in Office Hours.
-
-> 🎥 All our meetings are live-streamed on YouTube and the recordings are linked in each meeting's agenda — so you can catch up anytime!
+For all communication channels, community meetings, and social media links, see the [Communication Channels](https://github.com/flatcar/Flatcar/blob/main/README.md#communication-channels) section in the README. Come hang out with us on [Discord](https://discord.gg/PMYjFUsJyq)!
 
 ---
 
@@ -134,20 +102,20 @@ These guides will give you a solid foundation for working with the SDK and help 
 Pull requests can be issued from repository branches (maintainers only) or from forks. The project treats all PRs equally for review and merge, regardless of origin.
 
 **Requirements:**
-- Successful build + test
+- Successful CI
 - At least one LGTM from a maintainer who is not the PR author
 - Approvers may be co-authors (allowing reviewers to suggest changes)
 
 **Stages:**
 
-| Stage | Description |
-|-------|-------------|
-| **1. Filed** | PR is created. Draft PRs only undergo build+test when explicitly requested. |
+| Stage                   | Description                                                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **1. Filed**            | PR is created. Draft PRs only undergo build+test when explicitly requested.                                      |
 | **2. Ready for Review** | Maintainers can begin reviewing and approve CI runs. Authors may file directly in this stage if the PR is ready. |
-| **3. Under Review** | Maintainers add comments, request changes, and vet against Flatcar's mission and core principles. |
-| **4. Merged or Closed** | PR is merged upon approval or closed without merge. |
+| **3. Under Review**     | Maintainers add comments, request changes, and vet against Flatcar's mission and core principles.                |
+| **4. Merged or Closed** | PR is merged upon approval or closed without merge.                                                              |
 
-> 💡 **Tip:** PR feeling stuck? Don't be shy — reach out on Matrix or bring it up in a community meeting. We're here to help and we want to see your contribution succeed!
+> 💡 **Tip:** PR feeling stuck? Don't be shy — reach out on [Discord](https://discord.gg/PMYjFUsJyq) or bring it up in a community meeting. We're here to help and we want to see your contribution succeed!
 
 ### Authoring PRs
 
@@ -185,13 +153,13 @@ Detailed information about the commit message goes here.
 
 #### The Rules
 
-| Rule | Details |
-|------|---------|
-| **Line length** | Title ≤ 72 characters; body wrapped at 72 characters |
-| **Blank line** | Separate title and body with one empty line |
-| **Title mood** | Use [imperative mood](https://chris.beams.io/posts/git-commit/#imperative) (e.g., "Add feature" not "Added feature") |
-| **Title punctuation** | No period at the end |
-| **Body punctuation** | End sentences with periods |
+| Rule                  | Details                                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Line length**       | Title ≤ 72 characters; body wrapped at 72 characters                                                                 |
+| **Blank line**        | Separate title and body with one empty line                                                                          |
+| **Title mood**        | Use [imperative mood](https://chris.beams.io/posts/git-commit/#imperative) (e.g., "Add feature" not "Added feature") |
+| **Title punctuation** | No period at the end                                                                                                 |
+| **Body punctuation**  | End sentences with periods                                                                                           |
 
 #### Examples
 
@@ -213,3 +181,6 @@ Updated bash to the latest one.
 ---
 
 Thanks for reading, and thank you so much for contributing! 🙏 We're thrilled to have you as part of the Flatcar community. If you have any questions at all, don't hesitate to reach out — we're always happy to help and can't wait to see what you build! 🎉
+
+[linux-sep-changes]: https://www.kernel.org/doc/html/latest/process/submitting-patches.html#separate-your-changes
+[linux-desc-changes]: https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -31,7 +31,7 @@ These steps require elevated access and must be completed by an existing maintai
   - `flatcar-ci`
   - `nebraska-maintainers`
   - Other repository-specific teams as applicable.
-- [ ] If the new maintainer will be involved in release management, add them to the Nebraska read-only (`ro`) or read-write (`rw`) groups in the Nebraska release process as appropriate.
+- [ ] If the new maintainer will be involved in release management, add them to the Nebraska read-only (`ro`) or read-write (`rw`) groups in the Nebraska release process as appropriate. See [RELEASES.md](./RELEASES.md) for the full release guide.
 
 ### CNCF Registration
 
@@ -94,6 +94,7 @@ These are steps you should complete yourself after your coordinator has provisio
 
 ### Community Channels
 
+- [ ] Join the Flatcar Discord server: [discord.gg/PMYjFUsJyq](https://discord.gg/PMYjFUsJyq)
 - [ ] Join the Flatcar Matrix room: [#flatcar:matrix.org](https://app.element.io/#/room/#flatcar:matrix.org)
 - [ ] Join the [#flatcar channel](https://kubernetes.slack.com/archives/C03GQ8B5XNJ) in the Kubernetes Slack workspace.
 
@@ -109,7 +110,7 @@ These are steps you should complete yourself after your coordinator has provisio
 - [ ] Schedule onboarding knowledge-sharing sessions with existing maintainers to cover key areas of the project. Suggested topics include:
   - Overview of the Flatcar build system and SDK
   - CI/CD pipeline and infrastructure
-  - Release management process
+  - Release management process (see [RELEASES.md](./RELEASES.md))
   - Security response process
   - Governance and decision-making
 - [ ] Read through the [Flatcar developer guides](https://www.flatcar.org/docs/latest/reference/developer-guides/) and the [SDK how-to](https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/).
@@ -123,6 +124,7 @@ These are steps you should complete yourself after your coordinator has provisio
 
 If you have any questions during onboarding, please reach out to the maintainer team via:
 
+- Discord: [discord.gg/PMYjFUsJyq](https://discord.gg/PMYjFUsJyq)
 - Matrix: [#flatcar:matrix.org](https://app.element.io/#/room/#flatcar:matrix.org)
 - Slack: [#flatcar](https://kubernetes.slack.com/archives/C03GQ8B5XNJ) in the Kubernetes Slack org
 - Private maintainer mailing list: `maintainers@flatcar-linux.org`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ _Flatcar Container Linux is a fully open source, minimal-footprint, secure by de
 
 Flatcar ships only the essentials needed to run containers — no package manager, no configuration drift. Its immutable, read-only filesystem minimizes attack surfaces, and atomic, automated updates keep your system secure and up-to-date without manual intervention.
 
+Don't forget to check out [flatcar.org](https://www.flatcar.org/) for documentation, guides, and other useful resources!
+
 ## Table of Contents
 
 - [Flatcar Container Linux](#flatcar-container-linux)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,16 @@ Flatcar Container Linux follows an **Alpha → Beta → Stable** release process
 - **New features** and major version upgrades enter Alpha, transition to Beta, then land in Stable.
 - **Bug fixes** are released directly to the affected channel (Alpha fixes go to Alpha, Beta to Beta, Stable to Stable).
 
-Releases are planned on a **14-day cadence**. Up-to-date planning status is reflected in our [release planning board](https://github.com/orgs/flatcar/projects/7). For the full release process documentation, see the [Release Guide](RELEASES.md).
+Within each channel, updates are planned on a **14-day cadence**. Major releases follow a broader rhythm:
+
+| Promotion | Target cadence |
+|-----------|----------------|
+| New major **Alpha** | Monthly |
+| Alpha → **Beta** | Every 2 months |
+| Beta → **Stable** | Every 3–4 months |
+| New **LTS** | Yearly |
+
+Up-to-date planning status is reflected in our [release planning board](https://github.com/orgs/flatcar/projects/7). For the full release process documentation, see the [Release Guide](RELEASES.md).
 
 ### LTS
 

--- a/README.md
+++ b/README.md
@@ -15,137 +15,213 @@
 
 # Flatcar Container Linux
 
-## Mission statement
+Welcome to the Flatcar community! Whether you're a user, contributor, or just curious — we're glad you're here! 👋
 
 _Flatcar Container Linux is a fully open source, minimal-footprint, secure by default and always up-to-date Linux distribution for running containers at scale._
+
+Flatcar ships only the essentials needed to run containers — no package manager, no configuration drift. Its immutable, read-only filesystem minimizes attack surfaces, and atomic, automated updates keep your system secure and up-to-date without manual intervention.
+
+## Table of Contents
+
+- [Flatcar Container Linux](#flatcar-container-linux)
+  - [Table of Contents](#table-of-contents)
+  - [Install and Operate Flatcar](#install-and-operate-flatcar)
+  - [Communication Channels](#communication-channels)
+      - [Social Media](#social-media)
+    - [Community Meetings](#community-meetings)
+      - [Office Hours](#office-hours)
+      - [Developer Syncs](#developer-syncs)
+  - [Report Bugs and Request Features](#report-bugs-and-request-features)
+  - [Participate and Contribute](#participate-and-contribute)
+    - [Becoming a Maintainer](#becoming-a-maintainer)
+  - [Project Status and Roadmap](#project-status-and-roadmap)
+  - [Release Process](#release-process)
+    - [LTS](#lts)
+  - [Project Governance](#project-governance)
+  - [Code of Conduct](#code-of-conduct)
+  - [Repositories and Subprojects](#repositories-and-subprojects)
+    - [Subprojects](#subprojects)
+  - [Reference](#reference)
+
+---
+
+## Install and Operate Flatcar
+
+Flatcar Container Linux has a dedicated [documentation site](https://www.flatcar.org/docs/latest/). Start here:
+
+- [Getting Started](https://www.flatcar.org/docs/latest/installing/) — covers Ignition, local testing with QEMU, automatic updates, and cloud providers
+
+| Resource                    | Link                                                     |
+| --------------------------- | -------------------------------------------------------- |
+| **Current Releases**        | [flatcar.org/releases](https://www.flatcar.org/releases) |
+| **Interoperability Matrix** | [interop-matrix.md](interop-matrix.md)                   |
+| **CIS Benchmarks**          | [CIS reports](CIS/README.md)                             |
+
+---
+
+## Communication Channels
+
+We're a friendly bunch and always excited to chat! Here's where you can find us:
+
+| Channel                  | Link                                                                                                           |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| **Discord** (preferred)  | [discord.gg/PMYjFUsJyq](https://discord.gg/PMYjFUsJyq) — text, voice & video with contributors and maintainers |
+| **Matrix**               | [#flatcar:matrix.org](https://app.element.io/#/room/#flatcar:matrix.org)                                       |
+| **Slack**                | [#flatcar](https://kubernetes.slack.com/archives/C03GQ8B5XNJ) (Kubernetes Slack)                               |
+| **GitHub Discussions**   | [flatcar/Flatcar/discussions](https://github.com/flatcar/Flatcar/discussions)                                  |
+| **Mailing List (Users)** | [flatcar-linux-user](https://groups.google.com/g/flatcar-linux-user)                                           |
+
+> 💡 Want to report a bug or request a feature? [File an issue](https://github.com/flatcar/Flatcar/issues/new/choose). Have a question or not sure where to start? Jump into one of our chats and ask — we're happy to help!
+
+#### Social Media
+
+| Platform     | Link                                                   |
+| ------------ | ------------------------------------------------------ |
+| **Mastodon** | [@flatcar@hachyderm.io](https://hachyderm.io/@flatcar) |
+| **Bluesky**  | [@flatcar.org](https://bsky.app/profile/flatcar.org)   |
+| **X**        | [@flatcar](https://x.com/flatcar)                      |
+
+### Community Meetings
+
+Come say hi! Check our [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_ii991mqrpta9en8o7ofd4v19g4@group.calendar.google.com) ([iCal](https://calendar.google.com/calendar/ical/c_ii991mqrpta9en8o7ofd4v19g4%40group.calendar.google.com/public/basic.ics)) for all meeting times.
+
+#### Office Hours
+
+|            |                                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **When**   | 2nd Wednesday of every month at 2:30pm UTC (double check calendar)                                                                   |
+| **Where**  | [meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours) (all you need is a browser, no installations/accounts required) |
+| **Agenda** | [Office Hours Discussions](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-office-hours)                           |
+
+Engage with the Flatcar community, learn about project directions, discuss contributions, and catch occasional demos of image-based Linux technologies. Each call includes a brief Release Planning update.
+
+#### Developer Syncs
+
+|            |                                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **When**   | 4th Wednesday of every month at 2:30pm UTC (check calendar)                                                                          |
+| **Where**  | [meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours) (all you need is a browser, no installations/accounts required) |
+| **Agenda** | [Developer Sync Discussions](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-developer-sync)                       |
+
+Backlog grooming, task planning, roadmap discussions, and day-to-day issues. If you want to get hands-on with development, this is the call for you!
+
+> 🎥 All meetings are live-streamed on YouTube — recordings are linked in each meeting's agenda.
+
+---
+
+## Report Bugs and Request Features
+
+Found a bug or have a feature request? [File an issue](https://github.com/flatcar/Flatcar/issues/new/choose) — please select the appropriate issue type to help us triage.
+
+> 💡 **Tip:** Want a new package in the base image? Use the "New Package Request" issue type and check out the [package addition guidelines](adding-new-packages.md).
+
+---
+
+## Participate and Contribute
+
+Thinking of making a contribution? Engage with the project early — comment on an existing issue or create a new one. Making your intent visible is often the key to getting your work accepted!
+
+For full details, check out our [Contributing Guide](CONTRIBUTING.md) which covers:
+
+| Topic                  | What you'll find                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Ways to Contribute** | Code, docs, community, outreach, and more                                                               |
+| **Finding Issues**     | Labels like `good first issue` and `help wanted`                                                        |
+| **Development Setup**  | SDK walkthrough and [developer guides](https://www.flatcar.org/docs/latest/reference/developer-guides/) |
+| **PR Lifecycle**       | From filing to merge                                                                                    |
+| **Commit Guidelines**  | Format, style, and best practices                                                                       |
+
+> 🌟 **New to Flatcar?** Consider building a [Flatcar App](https://github.com/flatcar/Flatcar/issues/2029) — a great hands-on way to learn!
+
+### Becoming a Maintainer
+
+The Flatcar maintainer path is laid out in our [governance document](governance.md).
+
+---
+
+## Project Status and Roadmap
+
+| Board                                                                    | Description                                                |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| [**Issue Tracker**](https://github.com/flatcar/Flatcar/issues)           | Short-term concerns — bugs and minor enhancements          |
+| [**Tactical Board**](https://github.com/orgs/flatcar/projects/7/views/1) | What maintainers and contributors are currently working on |
+| [**Release Board**](https://github.com/orgs/flatcar/projects/7/views/8)  | Completed items assigned to upcoming releases              |
+| [**Roadmap Board**](https://github.com/orgs/flatcar/projects/7/views/9)  | Epics, major features, and long-term items                 |
+
+---
+
+## Release Process
+
+Flatcar Container Linux follows an **Alpha → Beta → Stable** release process:
+
+- **New features** and major version upgrades enter Alpha, transition to Beta, then land in Stable.
+- **Bug fixes** are released directly to the affected channel (Alpha fixes go to Alpha, Beta to Beta, Stable to Stable).
+
+Releases are planned on a **14-day cadence**. Up-to-date planning status is reflected in our [release planning board](https://github.com/orgs/flatcar/projects/7). For the full release process documentation, see the [Release Guide](RELEASES.md).
+
+### LTS
+
+Some users prefer to avoid frequent version upgrades. The Flatcar **LTS channel** provides a longer support window:
+
+| Detail                 | Value                     |
+| ---------------------- | ------------------------- |
+| **Based on**           | A "golden Stable" release |
+| **Maintenance period** | 18 months                 |
+| **New LTS frequency**  | Every 12 months           |
+| **Upgrade window**     | 6 months overlap          |
+
+---
+
+## Project Governance
+
+Flatcar is a community-driven project. Every participant — bug reporter, feature requester, code contributor — is considered a contributor. Maintainers have commit access and help govern the project, driving it forward and maintaining its scope and vision.
+
+For full details see our [governance document](governance.md).
+
+| Resource            | Link                             |
+| ------------------- | -------------------------------- |
+| **Governance**      | [governance.md](governance.md)   |
+| **Maintainers**     | [MAINTAINERS.md](MAINTAINERS.md) |
+| **Security Policy** | [SECURITY.md](SECURITY.md)       |
+
+---
 
 ## Code of Conduct
 
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please contact [private Maintainer mailing list](maintainers@flatcar-linux.org) or the Linux Foundation mediator, Mishi Choudhary mishi@linux.com
-to report an issue.
+Please contact the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the Linux Foundation mediator, Mishi Choudhary ([mishi@linux.com](mailto:mishi@linux.com)), to report an issue.
 
-## Releases
+---
 
-See the [project website](https://www.flatcar.org/) for information about [current releases](https://www.flatcar.org/releases).
+## Repositories and Subprojects
 
-## Install and operate Flatcar
+All GitHub repositories that comprise Flatcar Container Linux can be found via the [Flatcar organization](https://github.com/flatcar) page.
 
-Flatcar Container Linux has a dedicated [documentation site](https://www.flatcar.org/docs/latest/).
+### Subprojects
 
-The getting started guide has further links to the topics Ignition, local testing with QEMU, controlling automatic updates, and usage with cloud providers:
+| Project                                                            | Description                                                                                                                                                                                   |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**Nebraska**](https://github.com/flatcar/nebraska)                | Update manager for Flatcar Container Linux — manages rollouts, update groups, and instance tracking                                                                                           |
+| [**sysext-bakery**](https://github.com/flatcar/sysext-bakery)      | Build and publish systemd-sysext images to extend Flatcar with additional software (e.g., Docker, Kubernetes)                                                                                 |
+| [**linode-garm**](https://github.com/flatcar/linode-garm)          | GARM provider for Linode — spin up GitHub Actions self-hosted runners on Linode infrastructure                                                                                                |
+| [**Flatcar Apps**](https://github.com/flatcar/Flatcar/issues/2029) | Reference implementations showing how to run services on Flatcar (e.g., [Minecraft](https://github.com/flatcar/flatcar-app-minecraft), [Jitsi](https://github.com/flatcar/flatcar-app-jitsi)) |
 
-* [Getting started](https://www.flatcar.org/docs/latest/installing/)
+---
 
-**Does Flatcar run in my environment?** Consult the [interop-matrix](interop-matrix.md).
+## Reference
 
-**Does Flatcar have CIS Benchmarks?** Consult the [CIS reports](CIS/README.md).
-
-## Report bugs and request features
-
-If you hit a bug, or have a feature request, please [file an issue](https://github.com/flatcar/Flatcar/issues/new/choose) right here in this github project.
-Please select the appropriate issue type to help us triage incoming requests. For example, if you would like a new package to be added to the base Flatcar image, use the "New Package Request" issue type. (In that specific case, please also see [adding new packages to the Flatcar Linux OS image](adding-new-packages.md) for general guidelines.)
-
-### Chat
-
-For quick questions or for just hanging out with the community please use:
-* Our Discord server: https://discord.gg/PMYjFUsJyq
-* Our matrix chat (via element.io): [https://app.element.io/#/room/#flatcar:matrix.org](https://app.element.io/#/room/#flatcar:matrix.org)
-* Our Slack channel in the Kubernetes Slack org: https://kubernetes.slack.com/archives/C03GQ8B5XNJ
-
-### Discussions
-
-For more far-reaching topics please have a look at our [discussions](https://github.com/flatcar/Flatcar/discussions). Feel free to open a new discussion if you don't find an existing one covering your topic.
-
-### Mailing lists
-
-Though the use of Github Discussions is encouraged (see above), we also maintain groups / mailing lists for a more old-fashioned way of having a discussion. Please note that we might consider to discontinue these mailing lists at some point in the future.
-* Flatcar Users: https://groups.google.com/g/flatcar-linux-user
-* Flatcar Devs: https://groups.google.com/g/flatcar-linux-dev
- 
-### Social Media/Fediverse
-
-You can follow the [Flatcar Mastodon account](https://hachyderm.io/@flatcar). While Mastodon, as an open platform, is our preferred social media channel, we also have an [account on X](https://x.com/flatcar).
-
-## Participate and contribute
-
-If you are thinking of making a contribution, then please engage with the project as early as possible -- by commenting on an existing issue, or creating a new issue, on GitHub. Consider the project’s mission, and how your contribution furthers it.
-Making your intent visible early on can be a major factor for getting your work accepted.
-
-For the general guidelines on making PRs/commits easier to review, please check out the project's [contribution guidelines](CONTRIBUTING.md).
-
-For an introduction to the Flatcar SDK and a walk-through of common developer cases like customising the OS image (e.g. adding or upgrading packages), have a look at our [developer guides](https://www.flatcar.org/docs/latest/reference/developer-guides/); particularly the [howto on building custom images from source](https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/).
-The guides aim to provide a solid base for working with the SDK to help you filing successful PRs to the Flatcar project.
-
-### Becoming a maintainer
-
-The Flatcar maintainer path is laid out in our [governance document](governance.md).
-
-## Project status and roadmap - What's everybody working on, right now and in the future?
-
-1. short-term concerns (bugs and minor enhancements) enter the project via our [issue tracker](https://github.com/flatcar/Flatcar/issues)
-2. our [tactical board](https://github.com/orgs/flatcar/projects/7/views/1) reflects the issues and PRs the maintainers and the contributors are currently engaged with
-3. items which are done will be assigned to an upcoming release on the [release board](https://github.com/orgs/flatcar/projects/7/views/8)
-   in our release planning calls
-
-Lastly, epics like major features and long-term items are reflected in our [roadmap board](https://github.com/orgs/flatcar/projects/7/views/9).
-
-Check out our Matrix and Slack channels (mentioned above) for getting into contact with maintainers, and consider joining our Flatcar Developer Sync (next section below) where contributors and maintainers coordinate our work.
-
-### Monthly Office hours and Developer Syncs
-
-We maintain a [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_ii991mqrpta9en8o7ofd4v19g4@group.calendar.google.com) ([iCal](https://calendar.google.com/calendar/ical/c_ii991mqrpta9en8o7ofd4v19g4%40group.calendar.google.com/public/basic.ics)) with both our Office Hours and Developer Sync meeting series which interested folks can comfortably import into the calendar app of their choice.
-
-Join us in our monthly [office hours meetings](../../discussions/categories/flatcar-office-hours) to engage with the Flatcar User community interactively, to learn about the project's directions, and to discuss contributions. We also conduct the occasional user-focused demo of technologies related to image-based Linux.
-Lastly, the call includes a brief Release Planning with an update on the changes in the next immediate releases.
-
-If you'd like to share something or if you have a pressing issue you'd like discussed, please let us know.
-Either comment on the respective meeting discussion, reach out to us on Matrix (see below), or simply join the meeting and speak up in the meeting's Q&A.
-
-**Flatcar Office Hours are on the second Wednesday of every month at 2:30pm UTC**
-
-* Meeting agendas are published in advance - check our [discussions section](../../discussions/categories/flatcar-office-hours) for examples.
-* Call link: [https://meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours)
-* A Youtube live stream (which also serves as the meeting's recording) will be published on the respective agenda when a meeting starts.
-
-
-**Flatcar Developer Syncs commence every 4th Wednesday of a month at 2:30pm UTC**
-
-While release planning is a recurring part of each community call we also conduct separate Developer Syncs for backlog grooming and task planning. We discuss Roadmap items, special projects, and day-to-day issues in these calls. If you want to participate and discuss or pick up work, that call is for you!
-Just like the Office Hours the call includes a brief Release Planning with an update on the changes in the next immediate releases.
-
-* Meeting agendas are published in advance - check our [discussions section](../../discussions/categories/flatcar-developer-sync) for examples.
-* Call link: [https://meet.flatcar.org/OfficeHours](https://meet.flatcar.org/OfficeHours)
-* A youtube live stream (which also serves as the meeting's recording) will be published on the respective agenda when a meeting starts.
-
-## Release process
-
-Flatcar Container Linux follows an Alpha-Beta-Stable release process. New features and major version upgrades will enter the Alpha channel for initial testing, then transition to Beta, before landing in Stable.
-
-Note that unlike features, bug fixes for any release channel will be released to that respective channel directly, i.e. Alpha bug fixes will be included in the next Alpha, Beta fixes will directly go to Beta, and Stable fixes will be released with the next Stable.
-
-We plan our releases in a 14-day cadence. The maintainer team holds fortnightly release meetings - both as recurring part of our monthly [community calls](tree/main/community-meetings/) as well as a separate meeting in-between the monthly community call cadence. Up-to-date planning status is reflected in our [release planning board](https://github.com/orgs/flatcar/projects/7).
-
-### LTS
-
-Some users prefer to avoid the operational impact of frequent version upgrades.
-For such users, the Flatcar project provides an "LTS channel".
-The LTS channel / branch is based on a "golden Stable" and is maintained for 18 months.
-A new LTS is branched from Stable every 12 months, leaving a 6 months window for LTS users to upgrade.
-
-## Project governance
-
-Flatcar is a community-driven project, with community members participating through the following forums:
-
-* Contributors.
-* Maintainers.
-
-Every participant of the open source project - bug reporter, feature requester, code contributor - is considered a contributor.
-
-Maintainers have commit access to one or more repositories and help govern the project, driving it forward and maintaining its scope and vision.
-Please find more details in our [governance doc](governance.md).
-
-## Repositories
-
-The github repositories that comprise Flatcar Container Linux can be found via the [organization](https://github.com/flatcar) page.
+| Document                                           | Description                                                                            |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [CONTRIBUTING.md](CONTRIBUTING.md)                 | How to contribute — finding issues, development setup, PR lifecycle, commit guidelines |
+| [RELEASES.md](RELEASES.md)                         | Release channels, downloads, and the release process                                   |
+| [governance.md](governance.md)                     | Project governance model, maintainer roles, and decision-making                        |
+| [MAINTAINERS.md](MAINTAINERS.md)                   | Current list of project maintainers                                                    |
+| [EMERITUS_MAINTAINERS.md](EMERITUS_MAINTAINERS.md) | Former maintainers who have stepped down                                               |
+| [ONBOARDING.md](ONBOARDING.md)                     | Checklist for onboarding new maintainers                                               |
+| [SECURITY.md](SECURITY.md)                         | Security policy and vulnerability reporting                                            |
+| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)           | CNCF Code of Conduct                                                                   |
+| [adding-new-packages.md](adding-new-packages.md)   | Guidelines for requesting and adding new packages to Flatcar                           |
+| [interop-matrix.md](interop-matrix.md)             | Platform and provider interoperability matrix                                          |
+| [CODEOWNERS](CODEOWNERS)                           | Code ownership and review assignments                                                  |
+| [LICENSE](LICENSE)                                 | Project license (Apache 2.0)                                                           |

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Don't forget to check out [flatcar.org](https://www.flatcar.org/) for documentat
     - [LTS](#lts)
   - [Project Governance](#project-governance)
   - [Code of Conduct](#code-of-conduct)
-  - [Repositories and Subprojects](#repositories-and-subprojects)
-    - [Subprojects](#subprojects)
   - [Reference](#reference)
 
 ---
@@ -148,6 +146,7 @@ The Flatcar maintainer path is laid out in our [governance document](governance.
 | [**Issue Tracker**](https://github.com/flatcar/Flatcar/issues)           | Short-term concerns — bugs and minor enhancements          |
 | [**Tactical Board**](https://github.com/orgs/flatcar/projects/7/views/1) | What maintainers and contributors are currently working on |
 | [**Release Board**](https://github.com/orgs/flatcar/projects/7/views/8)  | Completed items assigned to upcoming releases              |
+| [**Releases Tracker**](https://github.com/orgs/flatcar/projects/7/views/24) | Track the status of each release across all channels    |
 | [**Roadmap Board**](https://github.com/orgs/flatcar/projects/7/views/9)  | Epics, major features, and long-term items                 |
 
 ---
@@ -193,21 +192,6 @@ For full details see our [governance document](governance.md).
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 Please contact the [private Maintainer mailing list](mailto:maintainers@flatcar-linux.org) or the Linux Foundation mediator, Mishi Choudhary ([mishi@linux.com](mailto:mishi@linux.com)), to report an issue.
-
----
-
-## Repositories and Subprojects
-
-All GitHub repositories that comprise Flatcar Container Linux can be found via the [Flatcar organization](https://github.com/flatcar) page.
-
-### Subprojects
-
-| Project                                                            | Description                                                                                                                                                                                   |
-| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**Nebraska**](https://github.com/flatcar/nebraska)                | Update manager for Flatcar Container Linux — manages rollouts, update groups, and instance tracking                                                                                           |
-| [**sysext-bakery**](https://github.com/flatcar/sysext-bakery)      | Build and publish systemd-sysext images to extend Flatcar with additional software (e.g., Docker, Kubernetes)                                                                                 |
-| [**linode-garm**](https://github.com/flatcar/linode-garm)          | GARM provider for Linode — spin up GitHub Actions self-hosted runners on Linode infrastructure                                                                                                |
-| [**Flatcar Apps**](https://github.com/flatcar/Flatcar/issues/2029) | Reference implementations showing how to run services on Flatcar (e.g., [Minecraft](https://github.com/flatcar/flatcar-app-minecraft), [Jitsi](https://github.com/flatcar/flatcar-app-jitsi)) |
 
 ---
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,14 +1,24 @@
 # Flatcar Releases
 
-Flatcar Container Linux uses **automatic, atomic updates** to keep your system secure and up-to-date without manual intervention. Each Flatcar instance receives updates from one of three release channels:
+Flatcar Container Linux uses **automatic, atomic updates** to keep your system secure and up-to-date without manual intervention. Each Flatcar instance receives updates from one of four release channels:
 
 - **Alpha** — the bleeding edge. New features, major version upgrades, and experimental changes land here first. Expect frequent updates and occasional rough edges.
 - **Beta** — a stabilization step. Changes that have proven themselves in Alpha are promoted here for broader testing before reaching production.
 - **Stable** — the default and recommended channel for production workloads. Only thoroughly tested releases make it here.
+- **LTS** — the gold standard for stability. An LTS release is cut from a battle-tested Stable version that has proven itself exceptionally reliable across the community. It receives only critical security and bug fix updates for **18 months**, with a new LTS published every 12 months and a 6-month overlap between consecutive LTS releases so you have plenty of time to upgrade. Ideal for environments where predictability and minimal change are paramount.
 
-Each channel always points to its latest version as the `current` release. Every release has its own version number and dedicated release notes. Bug fixes are shipped directly to the affected channel — an Alpha fix goes to Alpha, a Beta fix to Beta, a Stable fix to Stable.
+Each channel always points to its latest version as the `current` release. Every release has its own version number and dedicated release notes. Bug fixes are shipped directly to the affected channel — an Alpha fix goes to Alpha, a Beta fix to Beta, a Stable fix to Stable, and an LTS fix to LTS.
 
-Releases follow a **14-day cadence**. You can learn more about switching between channels and configuring update behavior in the [channel docs](https://www.flatcar.org/docs/latest/setup/releases/switching-channels/).
+Within each channel, updates are planned on a **14-day cadence**. Major releases follow a broader rhythm:
+
+| Promotion | Target cadence |
+|-----------|----------------|
+| New major **Alpha** | Monthly |
+| Alpha → **Beta** | Every 2 months |
+| Beta → **Stable** | Every 3–4 months |
+| New **LTS** | Yearly |
+
+You can learn more about switching between channels and configuring update behavior in the [channel docs](https://www.flatcar.org/docs/latest/setup/releases/switching-channels/).
 
 ## Download Images
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,28 @@
 # Flatcar Releases
 
-A Flatcar instance receives **automatic** updates from a specific release channel. The **Stable** channel is the default, and new major releases only appear there after passing through the **Alpha** and **Beta** channels. Each release channel always points to the latest release in that particular channel, linked as the `current` release. Each release has a version number and separate release notes.
+Flatcar Container Linux uses **automatic, atomic updates** to keep your system secure and up-to-date without manual intervention. Each Flatcar instance receives updates from one of three release channels:
 
-Learn more about updating and release channels in the [channel docs](https://www.flatcar.org/docs/latest/setup/releases/switching-channels/). Browse all available releases at [flatcar.org/releases](https://www.flatcar.org/releases/). Click `amd64` or `arm64` to download images for the channel's `current` release from the channel overview, or for a particular version from the release notes. You will be able to choose from many images for various platforms. The [installation docs](https://www.flatcar.org/docs/latest/installing/) have a quick start guide and information about public images directly available at each cloud provider.
+- **Alpha** — the bleeding edge. New features, major version upgrades, and experimental changes land here first. Expect frequent updates and occasional rough edges.
+- **Beta** — a stabilization step. Changes that have proven themselves in Alpha are promoted here for broader testing before reaching production.
+- **Stable** — the default and recommended channel for production workloads. Only thoroughly tested releases make it here.
 
-For the full release process documentation and how releases work under the hood, see the [Release Guide](https://www.flatcar.org/docs/latest/reference/developer-guides/release-guide/) on the Flatcar documentation site.
+Each channel always points to its latest version as the `current` release. Every release has its own version number and dedicated release notes. Bug fixes are shipped directly to the affected channel — an Alpha fix goes to Alpha, a Beta fix to Beta, a Stable fix to Stable.
+
+Releases follow a **14-day cadence**. You can learn more about switching between channels and configuring update behavior in the [channel docs](https://www.flatcar.org/docs/latest/setup/releases/switching-channels/).
+
+## Download Images
+
+Browse all available releases at [flatcar.org/releases](https://www.flatcar.org/releases/). Click `amd64` or `arm64` on the channel overview to download images for the `current` release, or navigate to a specific version's release notes to grab that particular build. You'll be able to choose from images for many platforms and cloud providers. The [installation docs](https://www.flatcar.org/docs/latest/installing/) have a quick start guide and information about public images directly available at each cloud provider.
+
+## Track Releases
+
+| Resource | Link |
+|----------|------|
+| **Releases Tracker** | [Project board](https://github.com/orgs/flatcar/projects/7/views/24) — status of each release across all channels |
+| **Release issues** | [kind/release](https://github.com/flatcar/Flatcar/issues?q=is%3Aissue+state%3Aopen+label%3Akind%2Frelease) — upcoming and in-progress releases that populate the tracker |
+
+## Release Process
+
+For the full release process documentation — how releases are built, tested, signed, and published — see the [Release Guide](https://www.flatcar.org/docs/latest/reference/developer-guides/release-guide/) on the Flatcar documentation site.
+
+Have questions about releases or updates? Join one of our [chats or community calls](https://github.com/flatcar/Flatcar/blob/main/README.md#communication-channels) — we're always happy to help!

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,7 @@
+# Flatcar Releases
+
+A Flatcar instance receives **automatic** updates from a specific release channel. The **Stable** channel is the default, and new major releases only appear there after passing through the **Alpha** and **Beta** channels. Each release channel always points to the latest release in that particular channel, linked as the `current` release. Each release has a version number and separate release notes.
+
+Learn more about updating and release channels in the [channel docs](https://www.flatcar.org/docs/latest/setup/releases/switching-channels/). Browse all available releases at [flatcar.org/releases](https://www.flatcar.org/releases/). Click `amd64` or `arm64` to download images for the channel's `current` release from the channel overview, or for a particular version from the release notes. You will be able to choose from many images for various platforms. The [installation docs](https://www.flatcar.org/docs/latest/installing/) have a quick start guide and information about public images directly available at each cloud provider.
+
+For the full release process documentation and how releases work under the hood, see the [Release Guide](https://www.flatcar.org/docs/latest/reference/developer-guides/release-guide/) on the Flatcar documentation site.


### PR DESCRIPTION
Refreshes the repo's core `.md` files for consistency, clarity, and completeness.

**Changes:**

- **README.md** — Full visual refactor: added welcome message and project intro paragraph, structured all sections with tables, added badges, consolidated communication channels (Discord as preferred), added community meetings (Office Hours & Developer Syncs), subprojects table (Nebraska, sysext-bakery, linode-garm, Flatcar Apps), and a Reference section linking all repo documents
- **CONTRIBUTING.md** — Replaced inline communication section with a link to README (single source of truth), updated channel references to mention Discord first, minor wording tweaks
- **ONBOARDING.md** — Added Discord to community channels checklist and support section, linked RELEASES.md from release management references
- **RELEASES.md** — Release channel overview, download instructions, and link to the full release guide